### PR TITLE
Update parser.ts to fully support semver

### DIFF
--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -2,7 +2,7 @@
 
 export function parseFile(file: string, defineName: string): string{
   if(defineName !== ""){
-      var regex = new RegExp(`\\s*\\#define\\s+${defineName}\\s+(?:\\"|\\')([\\d.]+)`);
+      var regex = new RegExp(/\s*\#define\s+/.source + defineName + /\s+(?:"|\')((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/.source);
   }
   else{
       var regex = /\s*version\s*=\s*(?:\"|\')([\d.]+)/;

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -2,7 +2,7 @@
 
 export function parseFile(file: string, defineName: string): string{
   if(defineName !== ""){
-      var regex = new RegExp(/\s*\#define\s+/.source + defineName + /\s+(?:"|\')((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/.source);
+      var regex = new RegExp(/\s*\#define\s+/.source + defineName + /\s+(?:"|\')(.*)"/.source);
   }
   else{
       var regex = /\s*version\s*=\s*(?:\"|\')([\d.]+)/;


### PR DESCRIPTION
Tested and works. Fixes #14 
```
D:\development\sourcemod-plugins\scripting>node
Welcome to Node.js v18.16.1.
Type ".help" for more information.
> let defineName = "PLUGIN_VERSION"
undefined
> let file = "rtd.sp"
undefined
> if(defineName !== ""){
...       var regex = new RegExp(/\s*\#define\s+/.source + defineName + /\s+(?:"|\')((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/.source);
...   } else{
...       var regex = /\s*version\s*=\s*(?:\"|\')([\d.]+)/;
...   }
undefined
>   const data = fs.readFileSync(file, 'utf8').split("\n");
Uncaught SyntaxError: Identifier 'data' has already been declared
>   var parsedVersion = "";
undefined
>   var match;
undefined
>   for(let line of data){
...       match = line.match(regex);
...       if(match !== null){
...           parsedVersion = match[1].trim();
...           break;
...       }
...   }
'2.3.6-beta.2'
>
```